### PR TITLE
Fix build with mtl >= 2.3

### DIFF
--- a/Data/Text/Punycode/Encode.hs
+++ b/Data/Text/Punycode/Encode.hs
@@ -2,6 +2,7 @@
 
 module Data.Text.Punycode.Encode (encode) where
 
+import           Control.Monad (when)
 import           Control.Monad.State hiding (state)
 import           Control.Monad.Writer
 import qualified Data.ByteString as BS


### PR DESCRIPTION
»Remove re-exports of Control.Monad […]« https://hackage.haskell.org/package/mtl-2.3.1/changelog#23----2022-05-07